### PR TITLE
Add RxJava

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,6 +95,13 @@ dependencies {
     annotationProcessor "com.google.dagger:dagger-android-processor:${rootProject.daggerVersion}"
     testAnnotationProcessor "com.google.dagger:dagger-compiler:${rootProject.daggerVersion}"
 
+    // Rx Java 2
+    implementation 'io.reactivex.rxjava2:rxjava:2.2.1'
+    implementation 'io.reactivex.rxjava2:rxandroid:2.1.0'
+
+    // Better "Subjects" for Rx
+    implementation 'com.jakewharton.rxrelay2:rxrelay:2.1.0'
+
     // tests
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.1.1'

--- a/app/src/main/java/com/contextgenesis/chatlauncher/dagger/AppModule.java
+++ b/app/src/main/java/com/contextgenesis/chatlauncher/dagger/AppModule.java
@@ -4,6 +4,11 @@ import android.app.Application;
 import android.content.Context;
 import android.content.pm.PackageManager;
 
+import com.contextgenesis.chatlauncher.rx.RxBus;
+import com.contextgenesis.chatlauncher.rx.RxEventBus;
+
+import javax.inject.Singleton;
+
 import dagger.Module;
 import dagger.Provides;
 
@@ -21,14 +26,14 @@ public class AppModule {
         return application;
     }
 
-    /*@Singleton
-    @Provides
-    EasyLocationMod provideLocation(Context context, RxBus rxBus) {
-        return new EasyLocationMod(context, rxBus);
-    }*/
-
     @Provides
     PackageManager providePackageManager(Context context) {
         return context.getPackageManager();
+    }
+
+    @Provides
+    @Singleton
+    RxBus provideRxEventBus() {
+        return new RxEventBus();
     }
 }

--- a/app/src/main/java/com/contextgenesis/chatlauncher/events/Event.java
+++ b/app/src/main/java/com/contextgenesis/chatlauncher/events/Event.java
@@ -1,0 +1,7 @@
+package com.contextgenesis.chatlauncher.events;
+
+/**
+ * Base class for events emitted via RxJava
+ */
+public class Event {
+}

--- a/app/src/main/java/com/contextgenesis/chatlauncher/rx/RxBus.java
+++ b/app/src/main/java/com/contextgenesis/chatlauncher/rx/RxBus.java
@@ -1,0 +1,33 @@
+package com.contextgenesis.chatlauncher.rx;
+
+import com.contextgenesis.chatlauncher.events.Event;
+import com.jakewharton.rxrelay2.Relay;
+
+import androidx.annotation.NonNull;
+import io.reactivex.Observable;
+
+public interface RxBus {
+
+    /**
+     * Registers for a particular event and returns an observable for subscription.
+     *
+     * @param eventClass the event
+     * @param <T>        the class type of the event
+     * @return observable that can be subscribed to.
+     */
+    <T> Observable<T> register(@NonNull Class<T> eventClass);
+
+    /**
+     * Registering to multiple sources
+     */
+    <T extends Event, T2 extends Event> Observable<Event> register(@NonNull Class<T> eventClass, @NonNull Class<T2> eventClass2);
+
+    /**
+     * Sends an event to all the observers who have registered to receive the event type.
+     *
+     * @param event an Event of any type.
+     */
+    void post(@NonNull Event event);
+
+    Relay<Object> getBusSubject();
+}

--- a/app/src/main/java/com/contextgenesis/chatlauncher/rx/RxEventBus.java
+++ b/app/src/main/java/com/contextgenesis/chatlauncher/rx/RxEventBus.java
@@ -1,0 +1,64 @@
+package com.contextgenesis.chatlauncher.rx;
+
+import com.contextgenesis.chatlauncher.events.Event;
+import com.jakewharton.rxrelay2.PublishRelay;
+import com.jakewharton.rxrelay2.Relay;
+
+import androidx.annotation.NonNull;
+import io.reactivex.Observable;
+import timber.log.Timber;
+
+/**
+ * A simple Event Bus powered by Jake Wharton's RxRelay and RxJava2
+ *
+ * @author rish
+ */
+
+public class RxEventBus implements RxBus {
+
+    private Relay<Object> busSubject;
+
+    public RxEventBus() {
+        busSubject = PublishRelay.create().toSerialized();
+    }
+
+    /**
+     * Registers for a particular event and returns an observable for subscription.
+     *
+     * @param eventClass the event
+     * @param <T>        the class type of the event
+     * @return observable that can be subscribed to.
+     */
+    @Override
+    public <T> Observable<T> register(@NonNull Class<T> eventClass) {
+        return busSubject
+                .filter(event -> event.getClass().equals(eventClass))
+                .map(obj -> (T) obj);
+    }
+
+    /**
+     * Registering to multiple sources
+     */
+    @Override
+    public <T extends Event, T2 extends Event> Observable<Event> register(@NonNull Class<T> eventClass, @NonNull Class<T2> eventClass2) {
+        return busSubject
+                .filter(event -> event.getClass().equals(eventClass) || event.getClass().equals(eventClass2))
+                .map(obj -> (Event) obj);
+    }
+
+    /**
+     * Sends an event to all the observers who have registered to receive the event type.
+     *
+     * @param event an Event of any type.
+     */
+    @Override
+    public void post(@NonNull Event event) {
+        Timber.d(event.toString());
+        busSubject.accept(event);
+    }
+
+    @Override
+    public Relay<Object> getBusSubject() {
+        return busSubject;
+    }
+}

--- a/app/src/main/java/com/contextgenesis/chatlauncher/rx/RxEventBus.java
+++ b/app/src/main/java/com/contextgenesis/chatlauncher/rx/RxEventBus.java
@@ -16,7 +16,7 @@ import timber.log.Timber;
 
 public class RxEventBus implements RxBus {
 
-    private Relay<Object> busSubject;
+    private final Relay<Object> busSubject;
 
     public RxEventBus() {
         busSubject = PublishRelay.create().toSerialized();

--- a/app/src/main/java/com/contextgenesis/chatlauncher/rx/scheduler/BaseSchedulerProvider.java
+++ b/app/src/main/java/com/contextgenesis/chatlauncher/rx/scheduler/BaseSchedulerProvider.java
@@ -1,0 +1,22 @@
+package com.contextgenesis.chatlauncher.rx.scheduler;
+
+import io.reactivex.Scheduler;
+
+
+/**
+ * Allow providing different types of {@link Scheduler}s.
+ */
+
+public interface BaseSchedulerProvider {
+
+    Scheduler runOnBackground();
+
+    Scheduler io();
+
+    Scheduler compute();
+
+    Scheduler androidThread();
+
+    Scheduler internet();
+}
+

--- a/app/src/main/java/com/contextgenesis/chatlauncher/rx/scheduler/ImmediateSchedulerProvider.java
+++ b/app/src/main/java/com/contextgenesis/chatlauncher/rx/scheduler/ImmediateSchedulerProvider.java
@@ -1,0 +1,40 @@
+package com.contextgenesis.chatlauncher.rx.scheduler;
+
+import io.reactivex.Scheduler;
+import io.reactivex.schedulers.Schedulers;
+
+/**
+ * Implementation of the {@link BaseSchedulerProvider} making all {@link Scheduler}s execute
+ * synchronously so we can easily run assertions in our tests.
+ * <p>
+ * To achieve this, we are using the {@link io.reactivex.internal.schedulers.TrampolineScheduler} from the {@link Schedulers} class.
+ */
+
+public class ImmediateSchedulerProvider implements BaseSchedulerProvider {
+
+    @Override
+    public Scheduler runOnBackground() {
+        return Schedulers.trampoline();
+    }
+
+    @Override
+    public Scheduler io() {
+        return Schedulers.trampoline();
+    }
+
+    @Override
+    public Scheduler compute() {
+        return Schedulers.trampoline();
+    }
+
+    @Override
+    public Scheduler androidThread() {
+        return Schedulers.trampoline();
+    }
+
+    @Override
+    public Scheduler internet() {
+        return Schedulers.trampoline();
+    }
+}
+

--- a/app/src/main/java/com/contextgenesis/chatlauncher/rx/scheduler/SchedulerProvider.java
+++ b/app/src/main/java/com/contextgenesis/chatlauncher/rx/scheduler/SchedulerProvider.java
@@ -1,0 +1,45 @@
+package com.contextgenesis.chatlauncher.rx.scheduler;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import io.reactivex.Scheduler;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.schedulers.Schedulers;
+
+/**
+ * @author rish
+ */
+
+public class SchedulerProvider implements BaseSchedulerProvider {
+
+    private static Executor backgroundExecutor = Executors.newCachedThreadPool();
+    private static Scheduler backgroundSchedulers = Schedulers.from(backgroundExecutor);
+    private static Executor internetExecutor = Executors.newCachedThreadPool();
+    private static Scheduler internetSchedulers = Schedulers.from(internetExecutor);
+
+    @Override
+    public Scheduler runOnBackground() {
+        return backgroundSchedulers;
+    }
+
+    @Override
+    public Scheduler io() {
+        return Schedulers.io();
+    }
+
+    @Override
+    public Scheduler compute() {
+        return Schedulers.computation();
+    }
+
+    @Override
+    public Scheduler androidThread() {
+        return AndroidSchedulers.mainThread();
+    }
+
+    @Override
+    public Scheduler internet() {
+        return internetSchedulers;
+    }
+}


### PR DESCRIPTION
Adds RxJava2

- Makes life a lot easier when dealing with async calls. Immediate use case will be when asking for permissions. Either we have a whole lot of callbacks from activities to the executors, or we do it this way.
- Using RxRelay to have a bus; having the bus allows us to register/unregister whenever/wherever we need it.